### PR TITLE
Camera offset delay in game mode

### DIFF
--- a/app/game/camera.py
+++ b/app/game/camera.py
@@ -3,6 +3,7 @@ import pygame
 from typing import Any
 
 from .._constants import SCR_W, SCR_H
+from ._constants import OFFSET_DELAY
 
 
 class Camera(pygame.sprite.LayeredUpdates):
@@ -13,6 +14,7 @@ class Camera(pygame.sprite.LayeredUpdates):
         self.offset = pygame.Vector2(0, 0)
         self.top_left = pygame.Vector2(0, 0)
         self.set_border = False
+        self.camera_delay = False
 
     def add_target(self, target: Any) -> None:
         self.target = target
@@ -26,12 +28,19 @@ class Camera(pygame.sprite.LayeredUpdates):
         super().update(offset=self.offset, **kwargs)
 
     def calculate_offset(self) -> None:
-        x = (self.target.rect.centerx - (SCR_W // 2)) - self.top_left.x
-        y = (self.target.rect.centery - (SCR_H // 2)) - self.top_left.y
+        """
+        Calculate the offset of the camera based on the target position and screen center.
+        """
+        target_pos = pygame.Vector2(self.target.rect.centerx, self.target.rect.centery)
+        screen_center = pygame.Vector2(SCR_W // 2, SCR_H // 2)
+        desired_offset = target_pos - screen_center - self.top_left
 
+        if self.camera_delay:
+            self.offset += (desired_offset - self.offset) / OFFSET_DELAY
+        else:
+            self.offset = desired_offset
+
+        # Clamp the offset to the borders of the level, not vertically
         if self.set_border:
-            x = max(0, min(x, self.width - SCR_W))
-            y = min(y, self.height - SCR_H)
-
-        self.offset.x = x
-        self.offset.y = y
+            self.offset.x = max(0, min(self.offset.x, self.width - SCR_W))
+            self.offset.y = min(self.offset.y, self.height - SCR_H)

--- a/app/game/game.py
+++ b/app/game/game.py
@@ -59,7 +59,8 @@ class Game:
             top_left=self.top_left,
             bottom_right=self.bottom_right,
             debug=self.debug,
-            set_border=True
+            set_border=True,
+            camera_delay=True
         )
 
         self.check_state()


### PR DESCRIPTION
Close #23 
This pull request includes several changes to the `Camera` class in the `app/game/camera.py` file to add a camera delay feature and improve the calculation of the camera offset. Additionally, a small change was made to the `loop` method in `app/game/game.py` to enable the camera delay.

Improvements to `Camera` class:

* [`app/game/camera.py`](diffhunk://#diff-94f5dd8c7c70f39b505e12c9434657e5b6383097b9b086b6536703f801cb6b65R6): Added `OFFSET_DELAY` import to support the camera delay feature.
* [`app/game/camera.py`](diffhunk://#diff-94f5dd8c7c70f39b505e12c9434657e5b6383097b9b086b6536703f801cb6b65R17): Added `camera_delay` attribute to the `Camera` class to control the delay feature.
* [`app/game/camera.py`](diffhunk://#diff-94f5dd8c7c70f39b505e12c9434657e5b6383097b9b086b6536703f801cb6b65L29-R46): Modified the `calculate_offset` method to use `camera_delay` and interpolate the offset based on `OFFSET_DELAY` when enabled.

Changes to `Game` class:

* [`app/game/game.py`](diffhunk://#diff-448329c4437f4e63a94c3cff1a86e67683d61275883d81c7410fc9392f2d9d25L62-R63): Updated the `loop` method to enable `camera_delay` when initializing the camera.